### PR TITLE
Windows 的にマズいファイル名を全角で代替する

### DIFF
--- a/lib/main.rb
+++ b/lib/main.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'fileutils'
 require 'net/http'
 
@@ -122,6 +123,14 @@ module Main
     title
       .gsub(/\s/, '_')
       .gsub(/\//, '_')
+      .gsub(/\?/, "？") # \/:*?"<>|
+      .gsub(/\\/, "￥")
+      .gsub(/:/, "：")
+      .gsub(/\*/, "＊")
+      .gsub(/\|/, "｜")
+      .gsub(/"/, '”')
+      .gsub(/</, "＜")
+      .gsub(/>/, "＞")
       .byteslice(0, 200).scrub('') # safe length for filename
   end
 

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'fileutils'
 require 'net/http'
 


### PR DESCRIPTION
windows 上でファイル名に使えない文字  `\/:*?"<>|` をいわゆる全角で代替する．
