### PR TITLE
設定した単語が含まれていたらシムリンク作成

### DIFF
--- a/config/settings.example.yml
+++ b/config/settings.example.yml
@@ -23,6 +23,14 @@ production:
         - QRR # bunka housou
         - LFR # nippon housou
 
+    # ファイル名に含まれる単語からシムリンクを作成
+    # archive_dirで設定したディレクトリ配下に 0_selections ディレクトリの作成、配下にシムリンク
+    # 定期的に聴きたいラジオをより分けるのに便利です
+    #selections:
+    #    - 花澤香菜
+    #    - 佐倉綾音
+    #    - モモノキ
+
     # trueの場合、音声のみのコンテンツ(音泉、アニたま、Radiko)を保存時に強制的にmp4へ変換します(再エンコードはかけないので音声は劣化しません)
     # Googleフォトなどにバックアップする際に便利です
     force_mp4: false

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -109,6 +109,18 @@ module Main
     unless File.exist?(latest_symlink)
       FileUtils.ln_s(dst, latest_symlink)
     end
+
+    # create selections symlink
+    if Settings.selections.present?
+      if Settings.selections.any? {|s| !!filename.match(s) }
+        selection_dir = "#{Settings.archive_dir}/0_selections"
+        selection_symlink = "#{selection_dir}/#{filename}"
+        FileUtils.mkdir_p(selection_dir)
+        unless File.exist?(selection_symlink)
+          FileUtils.ln_s(dst, selection_symlink)
+        end
+      end
+    end
   end
 
   def self.file_path_archive(ch_name, title, ext)


### PR DESCRIPTION
新年明けましておめでとうございます。

年末に佐倉綾音にドはまりしまして、佐倉綾音のラジオを毎回より分けるのも面倒なので指定した単語が含まれるファイル名の場合には別途シムリンクを張るようにしてみました。
おかげで佐倉綾音がより効率的に摂取出来るので大変便利になるかと思われます。こちらの変更を追加して欲しいと思うのですがどうでしょうか。

シムリンク張る場所が`"#{Settings.archive_dir}/0_selections"`とかにしてますが別の場所が良さそうとか、ここ処理変えた方が良さそうとかあれば何なりと。
