### PR TITLE
rec_one 録音タスクのマルチスレッド化

### DIFF
--- a/lib/main/main.rb
+++ b/lib/main/main.rb
@@ -184,41 +184,62 @@ module Main
     end
 
     def rec_one
-      job = nil
-      ActiveRecord::Base.transaction do
-        job = Job
-          .where(
-            "? <= `start` and `start` <= ?",
-            2.minutes.ago,
-            5.minutes.from_now
-          )
-          .where(state: Job::STATE[:scheduled])
-          .order(:start)
-          .lock
-          .first
-        unless job
-          return 0
+      jobs = nil
+      ActiveRecord::Base.connection_pool.with_connection do
+        ActiveRecord::Base.transaction do
+          jobs = Job
+            .where(
+              "? <= `start` and `start` <= ?",
+              2.minutes.ago,
+              5.minutes.from_now
+            )
+            .where(state: Job::STATE[:scheduled])
+            .order(:start)
+            .lock
+          unless jobs
+            return 0
+          end
         end
-
-        job.state = Job::STATE[:recording]
-        job.save!
       end
 
-      succeed = false
-      if job.ch == Job::CH[:ag]
-        succeed = Ag::Recording.new.record(job)
-      elsif Settings.radiru_channels && Settings.radiru_channels.include?(job.ch)
-        succeed = Radiru::Recording.new.record(job)
-      else
-        succeed = Radiko::Recording.new.record(job)
+      thread_array = []
+      jobs.each do |job|
+        thread_array << Thread.start(job) {|j|
+          Rails.logger.info "rec thread created. job:#{j.id}"
+
+          ActiveRecord::Base.connection_pool.with_connection do
+            j.state = Job::STATE[:recording]
+            j.save!
+          end
+
+          succeed = false
+          if j.ch == Job::CH[:ag]
+            succeed = Ag::Recording.new.record(j)
+          elsif Settings.radiru_channels && Settings.radiru_channels.include?(j.ch)
+            succeed = Radiru::Recording.new.record(j)
+          else
+            succeed = Radiko::Recording.new.record(j)
+          end
+
+          ActiveRecord::Base.connection_pool.with_connection do
+            j.state =
+              if succeed
+                Job::STATE[:done]
+              else
+                Job::STATE[:failed]
+              end
+            j.save!
+          end
+
+          Rails.logger.info "rec thread end. job:#{j.id}"
+        }
+
+        sleep 1
       end
-      job.state =
-        if succeed
-          Job::STATE[:done]
-        else
-          Job::STATE[:failed]
-        end
-      job.save!
+
+      thread_array.each do |th|
+        th.join
+      end
 
       return 0
     end


### PR DESCRIPTION
いまの main:rec_one は、1回の起動につき 1チャンネルの録音タスクしか起動しない && 起動される
のは番組開始 5分前～2分後の 7回なので、同時刻に複数のチャンネルで番組がはじまると、最大でも
7チャンネルしか同時に録音できません。

そこで、1回の起動で必要な分のタスクを一気にマルチスレッドで起動するようにしてみました。
A&G　+ Radiko + らじるらじる の計 17チャンネルで同時刻に番組が始まっても録音できるように
なります…が、私が動かしているメモリ 1GB の VPS ではときどきメモリ不足になったので、database.yml の
コネクションプール数を 2 に落としたところ、まあまあ安定して録音できるようになった気がします。

それでもときどき rtmpdump が落ちるので、落ちた時には番組終了時間まで繰り返しリトライをかけるように
しようかな…？と思っています。
