### PR TITLE
support for radiru m3u8 recording fail with ffmpeg status code 0.

### DIFF
--- a/lib/radiru/recording.rb
+++ b/lib/radiru/recording.rb
@@ -44,7 +44,7 @@ module Radiru
       length = job.length_sec + 60
       file_path = Main::file_path_working(job.ch, title(job), 'm4a')
       arg = "\
-        -loglevel error \
+        -loglevel warning \
         -y \
         -i #{Shellwords.escape(@m3u8_url)} \
         -t #{length} \
@@ -52,12 +52,9 @@ module Radiru
         #{Shellwords.escape(file_path)}"
 
       exit_status, output = Main::ffmpeg(arg)
-      unless exit_status.success?
+      unless exit_status.success? && output.blank?
         Rails.logger.error "rec failed. job:#{job.id}, exit_status:#{exit_status}, output:#{output}"
         return false
-      end
-      if output.present?
-        Rails.logger.warn "radiru ffmpeg command:#{arg} output:#{output}"
       end
 
       true


### PR DESCRIPTION
HLS ダウンロードにおける ffmpeg の仕様として、ダウンロードの途中でプレイリストや
セグメントデータが取得できずに異常終了した場合でも、ステータスコードは 0 を返すようです。

その結果、らじるらじるの録音に失敗したことを net-radio-archive が検知できなくなっていたので、
判定ロジックを修正しました。

結果、こんな感じで異常終了時に正しくエラーになります。

    E, [2017-09-07T18:50:20.499333 #14911] ERROR -- : rec failed. job:218718, exit_status:pid 14940 exit 0, 
    output:[https @ 0x4910e80] HTTP error 404 Not Found
    [hls,applehttp @ 0x489e360] Failed to reload playlist 0
    https://nhkradioakr1-i.akamaihd.net/hls/live/511633/1-r1/1-r1-01.m3u8: Server returned 404 Not Found
    
    E, [2017-09-07T19:05:14.822344 #15996] ERROR -- : rec failed. job:218763, exit_status:pid 16022 exit 0, 
    output:[hls,applehttp @ 0x581b360] Failed to reload playlist 0
    Last message repeated 1 times
