### PR TITLE
main:rm_working_files の 削除対象に *.m4a を追加

### DIFF
--- a/lib/main/workaround.rb
+++ b/lib/main/workaround.rb
@@ -19,6 +19,7 @@ module Main
       end
       `find #{Settings.working_dir} -ctime +#{Settings.working_files_retention_period_days || 7} -name "*.flv" -exec rm {} \\;`
       `find #{Settings.working_dir} -ctime +#{Settings.working_files_retention_period_days || 7} -name "*.mp3" -exec rm {} \\;`
+      `find #{Settings.working_dir} -ctime +#{Settings.working_files_retention_period_days || 7} -name "*.m4a" -exec rm {} \\;`
     end
 
     def self.rm_latest_dir_symlinks


### PR DESCRIPTION
らじるらじる対応してから大分経って今更なんですが、main:rm_working_files での
テンポラリファイル削除対象に、らじるの録音で生成する m4a が抜けてたので対応しました。