### PR TITLE
ffmpegのダウンロードURLを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,9 @@ RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 #=========
 # ffmpeg
 #=========
-RUN wget --no-verbose -O /tmp/ffmpeg.tar.gz http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz \
+RUN wget --no-verbose -O /tmp/ffmpeg.tar.gz https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz \
   && tar -C /tmp -xf /tmp/ffmpeg.tar.gz \
-  && mv /tmp/ffmpeg-*-64bit-static/ffmpeg /usr/bin \
+  && mv /tmp/ffmpeg-*-amd64-static/ffmpeg /usr/bin \
   && rm -rf /tmp/ffmpeg*
 
 #=========

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ $ sudo apt-get install rtmpdump swftools ruby git mysql-server-5.6 mysql-client-
 $ sudo service mysql start # WSLだとっぽい表示がでるかもしれませんがプロセスが起動していればOK
 
 $ # libavがインストールされている場合には削除してから
-$ wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
-$ tar xvf ffmpeg-release-64bit-static.tar.xz
-$ sudo cp ./ffmpeg-release-64bit-static/ffmpeg /usr/local/bin
+$ wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+$ tar xvf ffmpeg-release-amd64-static.tar.xz
+$ sudo cp ./ffmpeg-release-amd64-static/ffmpeg /usr/local/bin
 
 $ git clone https://github.com/yayugu/net-radio-archive.git
 $ cd net-radio-archive


### PR DESCRIPTION
ffmpegのダウンロードURL(`http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz`)が404でしたので、`https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz`  に修正しました。
Dockerfile のみ検証を行いました。

初めての Pull request なので何か不備がありましたら、ご指摘お願いします。